### PR TITLE
Replace all instances of dash/underscore

### DIFF
--- a/lib/dachshund.js
+++ b/lib/dachshund.js
@@ -14,7 +14,7 @@ function dashize(file, suppress) {
       return;
     }
 
-    const newPath = file.replace('_', '-');
+    const newPath = file.replace(/_/g, '-');
     if (file === newPath && !suppress) {
       console.error(`No need to change ${newPath}`);
     } else if (file !== newPath) {
@@ -34,7 +34,7 @@ function underscorize(file, suppress) {
       return;
     }
 
-    const newPath = file.replace('-', '_');
+    const newPath = file.replace(/-/g, '_');
     if (file === newPath && !suppress) {
       console.error(`No need to change ${newPath}`);
     } else if (file !== newPath) {


### PR DESCRIPTION
The description makes it sound like it should replace _all_ instances of dashes/underscores, not just the first one!

**Example issues:**

```
$ dunder another-file-name
another-file-name => another_file-name
```

```
$ udash another_file_name
another_file_name => another-file_name
```

Sorry, no tests. :see_no_evil: 
